### PR TITLE
Make the routes config dynamically

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -125,7 +125,7 @@ class ImpersonateManager
      */
     public function getTakeRedirectTo()
     {
-        return config('laravel-impersonate.take_redirect_to');
+        return route(config('laravel-impersonate.take_redirect_to'));
     }
 
     /**
@@ -133,6 +133,6 @@ class ImpersonateManager
      */
     public function getLeaveRedirectTo()
     {
-        return config('laravel-impersonate.leave_redirect_to');
+        return route(config('laravel-impersonate.leave_redirect_to'));
     }
 }

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -125,7 +125,13 @@ class ImpersonateManager
      */
     public function getTakeRedirectTo()
     {
-        return route(config('laravel-impersonate.take_redirect_to'));
+        try {
+            $uri = route(config('laravel-impersonate.take_redirect_to'));
+        } catch (\InvalidArgumentException $e) {
+            $uri = config('laravel-impersonate.take_redirect_to');
+        }
+
+        return $uri;
     }
 
     /**
@@ -133,6 +139,12 @@ class ImpersonateManager
      */
     public function getLeaveRedirectTo()
     {
-        return route(config('laravel-impersonate.leave_redirect_to'));
+        try {
+            $uri = route(config('laravel-impersonate.leave_redirect_to'));
+        } catch (\InvalidArgumentException $e) {
+            $uri = config('laravel-impersonate.leave_redirect_to');
+        }
+
+        return $uri;
     }
 }


### PR DESCRIPTION
In the `config/laravel-impersonate.php` the `take_redirect_to` and `leave_redirect_to` are hard coded urls. This is fine as long as you don't construct your routes dynamically.

In our case we hook into the `RouteServiceProvider` to add a language prefix `de` or `en`, depending on the user settings.

Since `route()` in a config file leads to a "Route not defined" error, because Laravel loads the configuration before the routes are registered, the only way to tackle this is to expect a route name.

The PR supports the old behavior and adds the new behavior on top.