### PR TITLE
Update read.me

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ composer require lab404/laravel-impersonate
 
 ## Simple usage
 
-Impersonate an user:
+Impersonate a user:
 ```php
 Auth::user()->impersonate($other_user);
 // You're now logged as the $other_user


### PR DESCRIPTION
"a user" not "an user" and here is why

If the sound of the first letter is like Y then we use a, like a user, because u in user is like y. Otherwise, we use an, like an apple, an orange... Answer: ... For example, the word "user" is pronounced "yoozer" (the initial "y" sound acts as a consonant) so it must be preceded by an "a," not an "an."