### PR TITLE
Detailed guards

### DIFF
--- a/migrations/2017_02_11_000000_create_users_table.php
+++ b/migrations/2017_02_11_000000_create_users_table.php
@@ -23,6 +23,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->boolean('is_admin')->default(0)->index();
             $table->boolean('can_be_impersonated')->default(1)->index();
+            // $table->string('role')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/migrations/2017_02_11_000000_create_users_table.php
+++ b/migrations/2017_02_11_000000_create_users_table.php
@@ -21,36 +21,42 @@ class CreateUsersTable extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->boolean('is_admin')->default(0)->index();
-            $table->boolean('can_be_impersonated')->default(1)->index();
-            // $table->string('role')->nullable();
+            $table->string('role')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });
 
         DB::table('users')->insert([
             [
+                'id'         =>  1,
                 'name'       => 'Admin',
                 'email'      => 'admin@test.rocks',
                 'password'   => bcrypt('password'),
-                'is_admin'   => 1,
-                'can_be_impersonated' => 1,
+                'role'       => 'admin',
                 'created_at' => Carbon::now()->toDateTimeString(),
             ],
             [
+                'id'         =>  2,
                 'name'       => 'User',
                 'email'      => 'user@test.rocks',
                 'password'   => bcrypt('password'),
-                'is_admin'   => 0,
-                'can_be_impersonated' => 1,
+                'role'       => 'user',
                 'created_at' => Carbon::now()->toDateTimeString(),
             ],
             [
+                'id'         =>  3,
                 'name'       => 'SuperAdmin',
                 'email'      => 'superadmin@test.rocks',
                 'password'   => bcrypt('password'),
-                'is_admin'   => 1,
-                'can_be_impersonated' => 0,
+                'role'       => 'superadmin',
+                'created_at' => Carbon::now()->toDateTimeString(),
+            ],
+            [
+                'id'         =>  4,
+                'name'       => 'Manager',
+                'email'      => 'manager@test.rocks',
+                'password'   => bcrypt('password'),
+                'role'       => 'manager',
                 'created_at' => Carbon::now()->toDateTimeString(),
             ],
         ]);

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/404labfr/laravel-impersonate.svg?branch=master)](https://travis-ci.org/404labfr/laravel-impersonate) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/404labfr/laravel-impersonate/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/404labfr/laravel-impersonate/?branch=master)
 
 **Laravel Impersonate** makes it easy to **authenticate as your users**. Add a simple **trait** to your **user model** and impersonate as one of your users in one click.
- 
+
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Simple usage](#simple-usage)
@@ -59,7 +59,7 @@ Auth::user()->leaveImpersonation();
 
 ### Using the built-in controller
 
-In your routes file you must call the `impersonate` route macro. 
+In your routes file you must call the `impersonate` route macro.
 ```php
 Route::impersonate();
 ```
@@ -76,31 +76,31 @@ route('impersonate.leave')
 
 ### Defining impersonation authorization
 
-By default all users can **impersonate** an user.  
+By default all users can **impersonate** an user.
 You need to add the method `canImpersonate()` to your user model:
 
 ```php
     /**
      * @return bool
      */
-    public function canImpersonate()
+    public function canImpersonate($impersonated)
     {
         // For example
-        return $this->is_admin == 1;
+        return $this->is_admin == 1 && !$impersonated->is_superadmin;
     }
 ```
 
-By default all users can **be impersonated**.  
+By default all users can **be impersonated**.
 You need to add the method `canBeImpersonated()` to your user model to extend this behavior:
 
 ```php
     /**
      * @return bool
      */
-    public function canBeImpersonated()
+    public function canBeImpersonated($impersonator)
     {
         // For example
-        return $this->can_be_impersonate == 1;
+        return $this->can_be_impersonated == 1 || $impersonator->is_superadmin;
     }
 ```
 
@@ -125,7 +125,9 @@ $manager->findUserById($id);
 $manager->isImpersonating();
 
 // Impersonate an user. Pass the original user and the user you want to impersonate
-$manager->take($from, $to);
+$manager->take($from, $to); // Will check for the canBeImpersonated and canImpersonate guards and throw exceptions if they fail
+// or
+$manager->forceTake($from, $to);
 
 // Leave current impersonation
 $manager->leave();
@@ -138,8 +140,8 @@ $manager->getImpersonatorId();
 
 **Protect From Impersonation**
 
-You can use the middleware `impersonate.protect` to protect your routes against user impersonation.  
-This middleware can be useful when you want to protect specific pages like users subscriptions, users credit cards, ... 
+You can use the middleware `impersonate.protect` to protect your routes against user impersonation.
+This middleware can be useful when you want to protect specific pages like users subscriptions, users credit cards, ...
 
 ```php
 Router::get('/my-credit-card', function() {
@@ -157,7 +159,7 @@ Each events returns two properties `$event->impersonator` and `$event->impersona
 
 ## Configuration
 
-The package comes with a configuration file.  
+The package comes with a configuration file.
 
 Publish it with the following command:
 ```bash
@@ -193,7 +195,7 @@ There are three Blade directives available.
 ### When the user can be impersonated
 
 This comes in handy when you have a user list and want to show an "Impersonate" button next to all the users.
-But you don\'t want that button next to the current authenticated user neither to that users which should not be able to impersonated according your implementation of `canBeImpersonated()` . 
+But you don\'t want that button next to the current authenticated user neither to that users which should not be able to impersonated according your implementation of `canBeImpersonated()` .
 
 ```blade
 @canBeImpersonated($user)

--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -33,7 +33,7 @@ class ImpersonateController extends Controller
             abort(403);
         }
 
-        // Cannot impersonate again if you're already impersonate a user
+        // Cannot impersonate again if you're already impersonating a user
         if ($this->manager->isImpersonating()) {
             abort(403);
         }

--- a/src/Exceptions/CannotBeImpersonatedException.php
+++ b/src/Exceptions/CannotBeImpersonatedException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Lab404\Impersonate\Exceptions;
+
+class CannotBeImpersonatedException extends ImpersonationException {}

--- a/src/Exceptions/CannotImpersonateException.php
+++ b/src/Exceptions/CannotImpersonateException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Lab404\Impersonate\Exceptions;
+
+class CannotImpersonateException extends ImpersonationException {}

--- a/src/Exceptions/ImpersonationException.php
+++ b/src/Exceptions/ImpersonationException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Lab404\Impersonate\Exceptions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class ImpersonationException extends Exception
+{
+    /**
+     * The model trying to impersonate another user.
+     *
+     * @var Illuminate\Database\Eloquent\Model
+     */
+    public $impersonator;
+
+    /**
+     * The model another user is trying to impersonate.
+     *
+     * @var Illuminate\Database\Eloquent\Model
+     */
+    public $impersonated;
+
+    /**
+     * Assigns the impersonator and the user impersonated to the exception.
+     *
+     * @param Model  $impersonator
+     * @param Model  $impersonated
+     */
+    public function __construct (Model $impersonator, Model $impersonated, ... $args)
+    {
+        $this->impersonator = $impersonator;
+        $this->impersonated = $impersonated;
+
+        parent::__construct(... $args);
+    }
+}

--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -76,8 +76,10 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
                 return '<?php endif; ?>';
             });
 
-            $bladeCompiler->directive('canImpersonate', function () {
-                return '<?php if (app()["auth"]->check() && app()["auth"]->user()->canImpersonate()): ?>';
+            $bladeCompiler->directive('canImpersonate', function ($expression) {
+                $user = trim($expression);
+
+                return "<?php if (app()[\"auth\"]->check() && app()[\"auth\"]->user()->canImpersonate({$user})): ?>";
             });
 
             $bladeCompiler->directive('endCanImpersonate', function () {
@@ -87,7 +89,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
             $bladeCompiler->directive('canBeImpersonated', function ($expression) {
                 $user = trim($expression);
 
-                return "<?php if (app()['auth']->check() && app()['auth']->user()->id != {$user}->id && {$user}->canBeImpersonated()): ?>";
+                return "<?php if (app()[\"auth\"]->check() && app()[\"auth\"]->user()->id != {$user}->id && {$user}->canBeImpersonated(app()[\"auth\"]->user())): ?>";
             });
 
             $bladeCompiler->directive('endCanBeImpersonated', function () {

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -65,7 +65,7 @@ class ImpersonateManager
     public function take($from, $to)
     {
         try {
-            session()->put(config('laravel-impersonate.session_key'), $from->getKey());
+            session()->put($this->getSessionKey(), $from->getKey());
 
             $this->app['auth']->quietLogout();
             $this->app['auth']->quietLogin($to);
@@ -91,7 +91,7 @@ class ImpersonateManager
 
             $this->app['auth']->quietLogout();
             $this->app['auth']->quietLogin($impersonator);
-            
+
             $this->clear();
 
         } catch (\Exception $e) {

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -29,7 +29,7 @@ class BladeDirectivesTest extends TestCase
      * @param   array $with
      * @return  void
      */
-    protected function makeView($view = 'impersonate', array $with = [])
+    protected function makeView($view, array $with = [])
     {
         $this->view = (string)$this->app['view']->make($view, $with);
     }
@@ -47,21 +47,21 @@ class BladeDirectivesTest extends TestCase
     public function it_displays_can_impersonate_content_directive()
     {
         $this->actingAs($this->admin);
-        $this->makeView();
+        $this->makeView('impersonate', ['user' => $this->user]);
         $this->assertContains('Impersonate this user', $this->view);
 
         $this->admin->impersonate($this->user);
         $this->admin->leaveImpersonation();
-        $this->makeView();
+        $this->makeView('impersonate', ['user' => $this->user]);
         $this->assertContains('Impersonate this user', $this->view);
         $this->logout();
     }
 
     /** @test */
-    public function it_not_displays_can_impersonate_content_directive()
+    public function it_does_not_display_can_impersonate_content_directive()
     {
         $this->actingAs($this->user);
-        $this->makeView();
+        $this->makeView('impersonate', ['user' => $this->admin]);
         $this->assertNotContains('Impersonate this user', $this->view);
         $this->logout();
     }
@@ -71,23 +71,23 @@ class BladeDirectivesTest extends TestCase
     {
         $this->actingAs($this->admin);
         $this->admin->impersonate($this->user);
-        $this->makeView();
+        $this->makeView('impersonate');
         $this->assertContains('Leave impersonation', $this->view);
         $this->logout();
     }
 
     /** @test */
-    public function it_not_displays_impersonating_content_directive()
+    public function it_does_not_display_impersonating_content_directive()
     {
         $this->actingAs($this->user);
-        $this->makeView();
+        $this->makeView('impersonate');
         $this->assertNotContains('Leave impersonation', $this->view);
         $this->logout();
 
         $this->actingAs($this->admin);
         $this->admin->impersonate($this->user);
         $this->admin->leaveImpersonation();
-        $this->makeView();
+        $this->makeView('impersonate');
         $this->assertNotContains('Leave impersonation', $this->view);
         $this->logout();
     }

--- a/tests/ImpersonateManagerTest.php
+++ b/tests/ImpersonateManagerTest.php
@@ -96,4 +96,41 @@ class ImpersonateManagerTest extends TestCase
         $this->assertEquals('impersonator_token', $admin->remember_token);
         $this->assertEquals('impersonated_token', $user->remember_token);
     }
+
+    /**
+     * @test
+     * @expectedException Lab404\Impersonate\Exceptions\CannotBeImpersonatedException
+     */
+    public function impersonating_an_unimpersonable_user_throws_exception()
+    {
+        $manager = $this->app['auth']->loginUsingId(4);
+        $admin   = $this->manager->findUserById(1);
+
+        $manager->impersonate($admin);
+    }
+
+    /**
+     * @test
+     * @expectedException Lab404\Impersonate\Exceptions\CannotImpersonateException
+     */
+    public function a_user_impersonating_an_admin_throws_an_exception()
+    {
+        $user  = $this->app['auth']->loginUsingId(2);
+        $admin = $this->manager->findUserById(1);
+
+        $user->impersonate($admin);
+    }
+
+    /** @test */
+    public function impersonating_a_user_can_be_forced()
+    {
+        $user  = $this->app['auth']->loginUsingId(2);
+        $admin = $this->manager->findUserById(1);
+
+        $this->manager->forceTake($user, $admin);
+
+        $this->assertEquals(1, $this->app['auth']->user()->getKey());
+        $this->assertEquals(2, $this->manager->getImpersonatorId());
+        $this->assertTrue($this->manager->isImpersonating());
+    }
 }

--- a/tests/ModelImpersonateTest.php
+++ b/tests/ModelImpersonateTest.php
@@ -2,36 +2,48 @@
 
 namespace Lab404\Tests;
 
+use Exception;
 use Lab404\Impersonate\Services\ImpersonateManager;
 
 class ModelImpersonateTest extends TestCase
 {
+    /**
+     * Returns the user specified by id.
+     *
+     * @param  int $id
+     * @return Illuminate\Database\Eloquent\Model
+     */
+    public function getUser($id)
+    {
+        return $this->app[ImpersonateManager::class]->findUserById($id);
+    }
+
     /** @test */
     public function it_can_impersonate()
     {
         $user = $this->app['auth']->loginUsingId(1);
-        $this->assertTrue($user->canImpersonate());
+        $this->assertTrue($user->canImpersonate($this->getUser(2)));
     }
 
     /** @test */
     public function it_cant_impersonate()
     {
         $user = $this->app['auth']->loginUsingId(2);
-        $this->assertFalse($user->canImpersonate());
+        $this->assertFalse($user->canImpersonate($this->getUser(1)));
     }
 
     /** @test */
     public function it_can_be_impersonate()
     {
         $user = $this->app['auth']->loginUsingId(1);
-        $this->assertTrue($user->canBeImpersonated());
+        $this->assertTrue($user->canBeImpersonated($this->getUser(3)));
     }
 
     /** @test */
     public function it_cant_be_impersonate()
     {
         $user = $this->app['auth']->loginUsingId(3);
-        $this->assertFalse($user->canBeImpersonated());
+        $this->assertFalse($user->canBeImpersonated($this->getUser(1)));
     }
 
     /** @test */
@@ -39,7 +51,7 @@ class ModelImpersonateTest extends TestCase
     {
         $admin = $this->app['auth']->loginUsingId(1);
         $this->assertFalse($admin->isImpersonated());
-        $user  = $this->app[ImpersonateManager::class]->findUserById(2);
+        $user  = $this->getUser(2);
         $admin->impersonate($user);
         $this->assertTrue($user->isImpersonated());
         $this->assertEquals($this->app['auth']->user()->getKey(), 2);
@@ -49,10 +61,24 @@ class ModelImpersonateTest extends TestCase
     public function it_can_leave_impersonation()
     {
         $admin = $this->app['auth']->loginUsingId(1);
-        $user  = $this->app[ImpersonateManager::class]->findUserById(2);
+        $user  = $this->getUser(2);
         $admin->impersonate($user);
         $admin->leaveImpersonation();
         $this->assertFalse($user->isImpersonated());
         $this->assertNotEquals($this->app['auth']->user()->getKey(), 2);
+    }
+
+    /** @test */
+    public function a_user_model_can_decide_if_it_can_be_impersonated_based_on_user_impersonating()
+    {
+        $manager = $this->app['auth']->loginUsingId(4);
+        $admin   = $this->getUser(1);
+
+        try {
+            $manager->impersonate($admin);
+        } catch(Exception $e) {}
+
+        $this->assertFalse($admin->isImpersonated());
+        $this->assertNotEquals($this->app['auth']->user()->getKey(), 1);
     }
 }

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -27,16 +27,29 @@ class User extends Authenticatable
     /**
      * @return  bool
      */
-    public function canImpersonate()
+    public function canImpersonate($impersonate_whom)
     {
-        return $this->attributes['is_admin'] == 1;
+        // Superadmins cannot be impersonated, so check for that.
+        return $this->role !== 'user' && in_array($impersonate_whom->role, ['user', 'manager', 'admin']);
     }
 
     /*
      * @return bool
      */
-    public function canBeImpersonated()
+    public function canBeImpersonated($impersonated_by)
     {
-        return $this->attributes['can_be_impersonated'] == 1;
+        if ($this->role === 'user') {
+            return true;
+        }
+
+        if ($this->role === 'manager') {
+            return in_array($impersonated_by, ['admin', 'superadmin']);
+        }
+
+        if ($this->role === 'admin') {
+            return $impersonated_by->role === 'superadmin';
+        }
+
+        return false;
     }
 }

--- a/tests/Stubs/views/impersonate.blade.php
+++ b/tests/Stubs/views/impersonate.blade.php
@@ -2,6 +2,8 @@
 <a href="{{ route('impersonate.leave') }}">Leave impersonation</a>
 @endImpersonating
 
-@canImpersonate
-<a href="{{ route('impersonate', 2) }}">Impersonate this user</a>
-@endCanImpersonate
+@if (!empty($user))
+	@canImpersonate($user)
+	<a href="{{ route('impersonate', $user->id) }}">Impersonate this user</a>
+	@endCanImpersonate
+@endif


### PR DESCRIPTION
In order to make the impersonation guards (`canImpersonate` and `canBeImpersonated`) as useful as possible, the opposite user (impersonated user for `canImpersonate` and impersonator for `canBeImpersonated`) is provided as an argument.

The ImpersonateManager checks if these guards are in place and checks if they return true. If not, the newly added `CannotBeImpersonatedException` and `CannotImpersonateException` will be thrown.

A `forceTake` can be used to omit these checks and definitely impersonate a user regardless of the guards.

This is a breaking change and should be introduced in the next major version.