### PR TITLE
Remove global scopes when finding user

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -32,12 +32,7 @@ class ImpersonateManager
     {
         $model = $this->app['config']->get('auth.providers.users.model');
 
-        $user = call_user_func([
-            $model,
-            'findOrFail'
-        ], $id);
-
-        return $user;
+        return app($model)->withoutGlobalScopes()->findOrFail($id);
     }
 
     /**


### PR DESCRIPTION
In the event that you have a global scope that limits available users, like in our case a user could only view their subordinates - implemented using a global scope, the function to reverse the impersonation fails since the impersonator is not a subordinate. This allows retrieval of the user without any global scope but only based on the id 
