### PR TITLE
Fire method was deprecated in 5.4 & removed in 5.8

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -75,7 +75,7 @@ class ImpersonateManager
             return false;
         }
 
-        $this->app['events']->fire(new TakeImpersonation($from, $to));
+        $this->app['events']->dispatch(new TakeImpersonation($from, $to));
 
         return true;
     }
@@ -91,7 +91,7 @@ class ImpersonateManager
 
             $this->app['auth']->quietLogout();
             $this->app['auth']->quietLogin($impersonator);
-            
+
             $this->clear();
 
         } catch (\Exception $e) {
@@ -99,7 +99,7 @@ class ImpersonateManager
             return false;
         }
 
-        $this->app['events']->fire(new LeaveImpersonation($impersonator, $impersonated));
+        $this->app['events']->dispatch(new LeaveImpersonation($impersonator, $impersonated));
 
         return true;
     }


### PR DESCRIPTION
As of Laravel 5.8, the `fire` method is removed in favor of `dispatch`....

https://laravel.com/docs/master/upgrade

This changes allows the package to be used in 5.8.

I have not fully vetted the code, as this is just a starting point to get it running.