### PR TITLE
Refactor events to use Authenticatable contract, use Userproviders instead of Eloquent

### DIFF
--- a/src/Events/LeaveImpersonation.php
+++ b/src/Events/LeaveImpersonation.php
@@ -3,7 +3,7 @@
 namespace Lab404\Impersonate\Events;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -15,10 +15,10 @@ class LeaveImpersonation
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    /** @var  Model */
+    /** @var Authenticatable */
     public $impersonator;
 
-    /** @var  Model */
+    /** @var Authenticatable */
     public $impersonated;
 
     /**
@@ -26,7 +26,7 @@ class LeaveImpersonation
      *
      * @return  void
      */
-    public function __construct(Model $impersonator, Model $impersonated)
+    public function __construct(Authenticatable $impersonator, Authenticatable $impersonated)
     {
         $this->impersonator = $impersonator;
         $this->impersonated = $impersonated;

--- a/src/Events/TakeImpersonation.php
+++ b/src/Events/TakeImpersonation.php
@@ -3,7 +3,7 @@
 namespace Lab404\Impersonate\Events;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -15,10 +15,10 @@ class TakeImpersonation
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    /** @var  Model */
+    /** @var  Authenticatable */
     public $impersonator;
 
-    /** @var  Model */
+    /** @var  Authenticatable */
     public $impersonated;
 
     /**
@@ -26,7 +26,7 @@ class TakeImpersonation
      *
      * @return  void
      */
-    public function __construct(Model $impersonator, Model $impersonated)
+    public function __construct(Authenticatable $impersonator, Authenticatable $impersonated)
     {
         $this->impersonator = $impersonator;
         $this->impersonated = $impersonated;

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -41,6 +41,8 @@ class ImpersonateManager
         $userProvider = $this->app['auth']->createUserProvider($providerName);
 
         if (!($modelInstance = $userProvider->retrieveById($id))) {
+            $model = $this->app['config']->get("auth.providers.$providerName.model");
+
             throw (new ModelNotFoundException())->setModel(
                 $model,
                 $id


### PR DESCRIPTION
Fixes #91 

This PR makes the library more reusable with different implementations outside of the Eloquent user providers. 

I did not alter or add any tests because the functionality is already tested.