### PR TITLE
Fix Authenticatable usage by using AuthIdentifier in session

### DIFF
--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -33,7 +33,7 @@ class ImpersonateController extends Controller
         $guardName = $guardName ?? $this->manager->getDefaultSessionGuard();
 
         // Cannot impersonate yourself
-        if ($id == $request->user()->getKey() && ($this->manager->getCurrentAuthGuardName() == $guardName)) {
+        if ($id == $request->user()->getAuthIdentifier() && ($this->manager->getCurrentAuthGuardName() == $guardName)) {
             abort(403);
         }
 

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -22,7 +22,7 @@ class ImpersonateManager
 
     /**
      * @param int $id
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Contracts\Auth\Authenticatable
      * @throws Exception
      */
     public function findUserById($id, $guardName = null)
@@ -60,7 +60,7 @@ class ImpersonateManager
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function getImpersonator()
     {
@@ -86,8 +86,8 @@ class ImpersonateManager
     }
 
     /**
-     * @param \Illuminate\Database\Eloquent\Model $from
-     * @param \Illuminate\Database\Eloquent\Model $to
+     * @param \Illuminate\Contracts\Auth\Authenticatable $from
+     * @param \Illuminate\Contracts\Auth\Authenticatable $to
      * @param string|null                         $guardName
      * @return bool
      */
@@ -97,7 +97,7 @@ class ImpersonateManager
 
         try {
             $currentGuard = $this->getCurrentAuthGuardName();
-            session()->put($this->getSessionKey(), $from->getKey());
+            session()->put($this->getSessionKey(), $from->getAuthIdentifier());
             session()->put($this->getSessionGuard(), $currentGuard);
             session()->put($this->getSessionGuardUsing(), $guardName);
 

--- a/tests/ModelImpersonateTest.php
+++ b/tests/ModelImpersonateTest.php
@@ -23,50 +23,50 @@ class ModelImpersonateTest extends TestCase
     /** @test */
     public function it_can_impersonate()
     {
-        $user = $this->app['auth']->loginUsingId(1);
+        $user = $this->app['auth']->loginUsingId('admin@test.rocks');
         $this->assertTrue($user->canImpersonate());
     }
 
     /** @test */
     public function it_cant_impersonate()
     {
-        $user = $this->app['auth']->loginUsingId(2);
+        $user = $this->app['auth']->loginUsingId('user@test.rocks');
         $this->assertFalse($user->canImpersonate());
     }
 
     /** @test */
     public function it_can_be_impersonate()
     {
-        $user = $this->app['auth']->loginUsingId(1);
+        $user = $this->app['auth']->loginUsingId('admin@test.rocks');
         $this->assertTrue($user->canBeImpersonated());
     }
 
     /** @test */
     public function it_cant_be_impersonate()
     {
-        $user = $this->app['auth']->loginUsingId(3);
+        $user = $this->app['auth']->loginUsingId('superadmin@test.rocks');
         $this->assertFalse($user->canBeImpersonated());
     }
 
     /** @test */
     public function it_impersonates()
     {
-        $admin = $this->app['auth']->loginUsingId(1);
+        $admin = $this->app['auth']->loginUsingId('admin@test.rocks');
         $this->assertFalse($admin->isImpersonated());
-        $user = $this->manager->findUserById(2, $this->guard);
+        $user = $this->manager->findUserById('user@test.rocks', $this->guard);
         $admin->impersonate($user, $this->guard);
         $this->assertTrue($user->isImpersonated());
-        $this->assertEquals($this->app['auth']->user()->getKey(), 2);
+        $this->assertEquals($this->app['auth']->user()->getAuthIdentifier(), 'user@test.rocks');
     }
 
     /** @test */
     public function it_can_leave_impersonation()
     {
-        $admin = $this->app['auth']->loginUsingId(1);
-        $user = $this->manager->findUserById(2, $this->guard);
+        $admin = $this->app['auth']->loginUsingId('admin@test.rocks');
+        $user = $this->manager->findUserById('user@test.rocks', $this->guard);
         $admin->impersonate($user, $this->guard);
         $admin->leaveImpersonation();
         $this->assertFalse($user->isImpersonated());
-        $this->assertNotEquals($this->app['auth']->user()->getKey(), 2);
+        $this->assertNotEquals($this->app['auth']->user()->getAuthIdentifier(), 'user@test.rocks');
     }
 }

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -39,4 +39,10 @@ class User extends Authenticatable
     {
         return $this->attributes['can_be_impersonated'] == 1;
     }
+
+
+    public function getAuthIdentifierName()
+    {
+        return 'email';
+    }
 }


### PR DESCRIPTION
The latest switch to Authenticatable was incomplete. It was still using the getKey value in the session instead of the getAuthIdentifier used by the retrieveById method of Authenticatable.