### PR TITLE
Laravel 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=7.1.3",
-    "laravel/framework": "5.8.* | ^6.0"
+    "laravel/framework": "5.8.* | ^6.0 | ^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5 | ^8.0",


### PR DESCRIPTION
This PR adds support for Laravel 7.0. 

As far as I know, there is no breaking change between 6 and 7, so it should be fine