### PR TITLE
Abort on null user provider name

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -32,6 +32,7 @@ class ImpersonateManager
         }
 
         $providerName = $this->app['config']->get("auth.guards.$guardName.provider");
+        abort_unless($providerName, 422);
         $userProvider = $this->app['auth']->createUserProvider($providerName);
 
         if (!($modelInstance = $userProvider->retrieveById($id))) {


### PR DESCRIPTION
Hello!
This PR is intended to signal the problem, but might require changes to serve as a definitive fix.
The problem is relatively simple. Someone can force an error if manually setting a missing guard in the route path, like this: https://mywebsite.com/impersonate/take/123/missingGuard

That will generate an exception `Call to a member function retrieveById() on null` in line 38 `if (!($modelInstance = $userProvider->retrieveById($id))) {`.

Be it with this particular fix or another, it'd be nice to validate that the guard is valid before trying to use it.

Hope this is clear enough.