### PR TITLE
fix cant leave impersonation with multiguard auth

### DIFF
--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -17,7 +17,7 @@ class ImpersonateController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth')->only('take');
 
         $this->manager = app()->make(ImpersonateManager::class);
     }

--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -17,9 +17,10 @@ class ImpersonateController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth')->only('take');
-
         $this->manager = app()->make(ImpersonateManager::class);
+        
+        $guard = $this->manager->getDefaultSessionGuard();
+        $this->middleware('auth:' . $guard)->only('take');
     }
 
     /**


### PR DESCRIPTION
fix cant leave impersonation with multiguard auth
- when using auth on `leave` you will be redirected to login when leaving a different guard other than `web` ex.`client -> web`
- after login u will be redirected to `leave` again which will now give `403` because u have already left the impersonation.

with this fix , everything works as it should & u still get `403` if u tried to visit `leave` without being authd because `isImpersonating()` requires user to be logged in in the first place.