### PR TITLE
Allow impersonating when already impersonated

### DIFF
--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -38,9 +38,8 @@ class ImpersonateController extends Controller
             abort(403);
         }
 
-        // Cannot impersonate again if you're already impersonate a user
         if ($this->manager->isImpersonating()) {
-            abort(403);
+            $this->manager->leave();
         }
 
         if (!$request->user()->canImpersonate()) {


### PR DESCRIPTION
This PR hopes to solve a situation where you can't re-impersonate when already impersonated.
The problem I'm trying to solve here has to do with the following situation:

1. You impersonate as an user, do a support-like thing or whatever, and afterwards forget to reverse-impersonate
2. You impersonate another user, get a 403 (because you can't impersonate twice)
3. You click back
4. You click reverse impersonate
5. You re-impersonate the user again (step 2)

Please note I didn't test this, but it seems rather straight-forward to me.

Thanks!