### PR TITLE
Readd impersonator password hash on leave

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -138,6 +138,9 @@ class ImpersonateManager
 
             $this->app['auth']->guard($this->getCurrentAuthGuardName())->quietLogout();
             $this->app['auth']->guard($this->getImpersonatorGuardName())->quietLogin($impersonator);
+            session()->put([
+                'password_hash_' . $this->getImpersonatorGuardName() => $impersonator->getAuthPassword(),
+            ]);
 
             $this->extractAuthCookieFromSession();
 


### PR DESCRIPTION
Possible solution to #134 

Currently the quietLogin() function does not set the guard password hash value on the session.