### PR TITLE
Set the duration of the "remember me" cookie according to configuration

### DIFF
--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -145,6 +145,10 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
                 $guard->setRequest($app->refresh('request', $guard, 'setRequest'));
             }
 
+            if (method_exists($guard, 'setRememberDuration') and isset($config['remember'])) {
+                $guard->setRememberDuration($config['remember']);
+            }
+
             return $guard;
         });
     }


### PR DESCRIPTION
Laravel 8.65.0, with the pull request https://github.com/laravel/framework/pull/39186, introduced a configuration variable for customizing the duration of the "remember me" cookie. Unfortunately, when using laravel-impersonate, that configuration is ignored. This pull request fixes that.