### PR TITLE
Support Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
   ],
   "require": {
     "php": "^7.2 | ^8.0",
-    "laravel/framework": "^6.0 | ^7.0 | ^8.0"
+    "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5 | ^8.0 | ^9.0",
     "mockery/mockery": "^1.3.3",
-    "orchestra/testbench": "^4.0 | ^5.0 | ^6.0",
-    "orchestra/database": "^4.0 | ^5.0 | ^6.0"
+    "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0",
+    "orchestra/database": "^4.0 | ^5.0 | ^6.0 | ^7.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
You could already create a new tag after merging this, as both Laravel and Testbench have set up branch aliases.