### PR TITLE
inject sandbox instance in service provider, always use fresh instanc…

### DIFF
--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -5,6 +5,7 @@ namespace Lab404\Impersonate;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
+use Illuminate\Container\Container;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Event;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -34,7 +35,9 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->bind(ImpersonateManager::class, ImpersonateManager::class);
 
         $this->app->singleton(ImpersonateManager::class, function ($app) {
-            return new ImpersonateManager($app);
+            return new ImpersonateManager(function () {
+                return Container::getInstance();
+            });
         });
 
         $this->app->alias(ImpersonateManager::class, 'impersonate');

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -2,6 +2,7 @@
 
 namespace Lab404\Impersonate\Services;
 
+use Closure;
 use Exception;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
@@ -19,9 +20,9 @@ class ImpersonateManager
     /** @var Application $app */
     private $app;
 
-    public function __construct(Application $app)
+    public function __construct(Closure $app)
     {
-        $this->app = $app;
+        $this->app = $app();
     }
 
     /**


### PR DESCRIPTION
This PR fixes stale instances of ImpersonateManager when using Laravel Octane. It was mentioned in #164 
When I try to leave impersonalization it wouldn't work because of that issue. 

I replaced `$this->manager` with fresh instances of ImpersonateManager using `app()->make(ImpersonateManager::class)`