### PR TITLE
Redirect url feature

### DIFF
--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -5,6 +5,7 @@ namespace Lab404\Impersonate\Controllers;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Session;
 use Lab404\Impersonate\Services\ImpersonateManager;
 
 class ImpersonateController extends Controller
@@ -51,7 +52,7 @@ class ImpersonateController extends Controller
 
         if ($userToImpersonate->canBeImpersonated()) {
             if ($this->manager->take($request->user(), $userToImpersonate, $guardName)) {
-                $takeRedirect = $this->manager->getTakeRedirectTo();
+                $takeRedirect = (Session::get('imp_back_url')) ? Session::get('imp_back_url') : $this->manager->getTakeRedirectTo();
                 if ($takeRedirect !== 'back') {
                     return redirect()->to($takeRedirect);
                 }
@@ -72,7 +73,9 @@ class ImpersonateController extends Controller
 
         $this->manager->leave();
 
-        $leaveRedirect = $this->manager->getLeaveRedirectTo();
+        $leaveRedirect = (Session::get('imp_back_url')) ? Session::get('imp_back_url') : $this->manager->getLeaveRedirectTo();
+        Session::forget('imp_back_url');
+
         if ($leaveRedirect !== 'back') {
             return redirect()->to($leaveRedirect);
         }

--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -52,6 +52,7 @@ class ImpersonateController extends Controller
 
         if ($userToImpersonate->canBeImpersonated()) {
             if ($this->manager->take($request->user(), $userToImpersonate, $guardName)) {
+                // Check if Session imp_back_url exist and redirect to that url or use the url from config file
                 $takeRedirect = (Session::get('imp_back_url')) ? Session::get('imp_back_url') : $this->manager->getTakeRedirectTo();
                 if ($takeRedirect !== 'back') {
                     return redirect()->to($takeRedirect);
@@ -74,7 +75,8 @@ class ImpersonateController extends Controller
         $this->manager->leave();
 
         $leaveRedirect = (Session::get('imp_back_url')) ? Session::get('imp_back_url') : $this->manager->getLeaveRedirectTo();
-        Session::forget('imp_back_url');
+        
+        Session::forget('imp_back_url'); // Will clean session for next use
 
         if ($leaveRedirect !== 'back') {
             return redirect()->to($leaveRedirect);


### PR DESCRIPTION
It is  a small improvement that will permit to pass a redirection url when it is needed.
To pass a url different from the used in config file:

Use `Session::put('imp_back_url', 'CUSTOM_URL');`

before impersonate

Example of use before impersonate:

```
if($request->back_url){
      $request->session()->put('imp_back_url', $request->back_url);
}

return redirect(route('impersonate', $request->user_id));
```

This session imp_back_url will be cleared when user leave impersonate.

With this small improvement it is posible to pass custom redirection url when needed or use default from config if it's not passed trough session.

It is working fine and solved my needs. 
I hope it's make sense. 