### PR TITLE
Allow for setting the redirect leave URL when impersonating a user

### DIFF
--- a/config/laravel-impersonate.php
+++ b/config/laravel-impersonate.php
@@ -18,6 +18,11 @@ return [
     'session_guard_using' => 'impersonator_guard_using',
 
     /**
+     * The session key used to store the URI to go to after leaving an impersonation.
+     */
+    'session_leave_redirect_to' => 'impersonator_leave_redirect_to',
+
+    /**
      * The default impersonator guard used.
      */
     'default_impersonator_guard' => 'web',

--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -49,8 +49,10 @@ class ImpersonateController extends Controller
 
         $userToImpersonate = $this->manager->findUserById($id, $guardName);
 
+        $leaveRedirectUrl = $request->get('leaveRedirectTo');
+
         if ($userToImpersonate->canBeImpersonated()) {
-            if ($this->manager->take($request->user(), $userToImpersonate, $guardName)) {
+            if ($this->manager->take($request->user(), $userToImpersonate, $guardName, $leaveRedirectUrl)) {
                 $takeRedirect = $this->manager->getTakeRedirectTo();
                 if ($takeRedirect !== 'back') {
                     return redirect()->to($takeRedirect);
@@ -70,9 +72,10 @@ class ImpersonateController extends Controller
             abort(403);
         }
 
+        $leaveRedirect = $this->manager->getLeaveRedirectTo();
+
         $this->manager->leave();
 
-        $leaveRedirect = $this->manager->getLeaveRedirectTo();
         if ($leaveRedirect !== 'back') {
             return redirect()->to($leaveRedirect);
         }

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -107,7 +107,7 @@ class ImpersonateManager
      * @param string|null                         $guardName
      * @return bool
      */
-    public function take($from, $to, $guardName = null)
+    public function take($from, $to, $guardName = null, $leaveRedirectUrl = null)
     {
         $this->saveAuthCookieInSession();
 
@@ -116,6 +116,7 @@ class ImpersonateManager
             session()->put($this->getSessionKey(), $from->getAuthIdentifier());
             session()->put($this->getSessionGuard(), $currentGuard);
             session()->put($this->getSessionGuardUsing(), $guardName);
+            session()->put($this->getSessionLeaveRedirectTo(), $leaveRedirectUrl);
 
             $this->app['auth']->guard($currentGuard)->quietLogout();
             $this->app['auth']->guard($guardName)->quietLogin($to);
@@ -158,6 +159,7 @@ class ImpersonateManager
         session()->forget($this->getSessionKey());
         session()->forget($this->getSessionGuard());
         session()->forget($this->getSessionGuardUsing());
+        session()->forget($this->getSessionLeaveRedirectTo());
     }
 
     public function getSessionKey(): string
@@ -180,6 +182,11 @@ class ImpersonateManager
         return config('laravel-impersonate.default_impersonator_guard');
     }
 
+    public function getSessionLeaveRedirectTo(): string
+    {
+        return config('laravel-impersonate.session_leave_redirect_to');
+    }
+
     public function getTakeRedirectTo(): string
     {
         try {
@@ -194,6 +201,10 @@ class ImpersonateManager
     public function getLeaveRedirectTo(): string
     {
         try {
+            if ($uri = session($this->getSessionLeaveRedirectTo())) {
+                return $uri;
+            }
+
             $uri = route(config('laravel-impersonate.leave_redirect_to'));
         } catch (\InvalidArgumentException $e) {
             $uri = config('laravel-impersonate.leave_redirect_to');

--- a/tests/ImpersonateControllerTest.php
+++ b/tests/ImpersonateControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Lab404\Tests;
+
+use Lab404\Impersonate\Services\ImpersonateManager;
+
+class ImpersonateControllerTest extends TestCase
+{
+    /** @var  ImpersonateManager $manager */
+    protected $manager;
+
+    /** @var  string $guard */
+    protected $guard;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manager = $this->app->make(ImpersonateManager::class);
+        $this->guard = 'web';
+    }
+
+    /** @test */
+    public function it_gets_leave_redirect_to_from_session_if_exists()
+    {
+        // Arrange
+        $leaveRedirectTo = 'http://example.com';
+        $this->app['session']->put($this->manager->getSessionLeaveRedirectTo(), $leaveRedirectTo);
+        $this->app['session']->put($this->manager->getSessionKey(), 'test_session_key');
+
+        // Act
+        $response = $this->get(route('impersonate.leave'));
+
+        // Assert
+        $response->assertRedirect($leaveRedirectTo);
+    }
+
+    /** @test */
+    public function it_gets_leave_redirect_to_from_query_parameter_and_stores_it_in_session()
+    {
+        // Arrange
+        $this->withoutExceptionHandling();
+        $this->app['auth']->loginUsingId('admin@test.rocks');
+        $leaveRedirectTo = 'http://example.com';
+
+        // Act
+        $response = $this->get(route('impersonate', ['id' => 'user@test.rocks', 'guardName' => 'web', 'leaveRedirectTo' => $leaveRedirectTo]));
+
+        // Assert
+        $this->assertEquals($leaveRedirectTo, $this->app['session']->get($this->manager->getSessionLeaveRedirectTo()));
+    }
+}

--- a/tests/ImpersonateManagerTest.php
+++ b/tests/ImpersonateManagerTest.php
@@ -214,4 +214,19 @@ class ImpersonateManagerTest extends TestCase
         $this->assertEquals($cookie->getName(), $response->headers->getCookies()[0]->getName());
         $this->assertEquals($cookie->getValue(), $response->headers->getCookies()[0]->getValue());
     }
+
+    /** @test */
+    public function it_puts_leave_redirect_to_in_session_when_take_is_called()
+    {
+        // Arrange
+        $this->app['auth']->loginUsingId('admin@test.rocks');
+        $leaveRedirectTo = 'http://localhost/custom-redirect-url';
+
+        // Act
+        $this->manager->take($this->app['auth']->user(), $this->manager->findUserById('user@test.rocks'), null, $leaveRedirectTo);
+
+        // Assert
+        $this->assertEquals($leaveRedirectTo, $this->app['session']->get($this->manager->getSessionLeaveRedirectTo()));
+    }
+
 }


### PR DESCRIPTION
This PR adds the ability of setting the redirect leave URL when starting to impersonate a user. It does this via a query parameter, and sets in the session if it is present. When leaving the impersonation it checks if it is present in the session and uses this as a redirect url.

I needed this feature for a project for a client I am working on. Hopefully you also find it useful and it can get merged to the package.  