### PR TITLE
spelling and grammar fixes

### DIFF
--- a/config/laravel-impersonate.php
+++ b/config/laravel-impersonate.php
@@ -8,7 +8,7 @@ return [
     'session_key' => 'impersonated_by',
 
     /**
-     * The session key used to stored the original user guard.
+     * The session key used to store the original user guard.
      */
     'session_guard' => 'impersonator_guard',
 

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ route('impersonate.leave')
 
 ### Defining impersonation authorization
 
-By default all users can **impersonate** an user.  
+By default, all users can **impersonate** a user.  
 You need to add the method `canImpersonate()` to your user model:
 
 ```php
@@ -117,7 +117,7 @@ You need to add the method `canImpersonate()` to your user model:
     }
 ```
 
-By default all users can **be impersonated**.  
+By default, all users can **be impersonated**.  
 You need to add the method `canBeImpersonated()` to your user model to extend this behavior:
 
 ```php
@@ -180,7 +180,7 @@ There are two events available that can be used to improve your workflow:
 - `TakeImpersonation` is fired when an impersonation is taken.
 - `LeaveImpersonation` is fired when an impersonation is leaved.
 
-Each events returns two properties `$event->impersonator` and `$event->impersonated` containing User model instance.
+Each event returns two properties `$event->impersonator` and `$event->impersonated` containing User model instance.
 
 ## Configuration
 

--- a/src/Models/Impersonate.php
+++ b/src/Models/Impersonate.php
@@ -8,7 +8,7 @@ use Lab404\Impersonate\Services\ImpersonateManager;
 trait Impersonate
 {
     /**
-     * Return true or false if the user can impersonate an other user.
+     * Return true or false if the user can impersonate another user.
      *
      * @param void
      * @return  bool
@@ -19,7 +19,7 @@ trait Impersonate
     }
 
     /**
-     * Return true or false if the user can be impersonate.
+     * Return true or false if the user can be impersonated.
      *
      * @param void
      * @return  bool

--- a/tests/MiddlewareProtectFromImpersonationTest.php
+++ b/tests/MiddlewareProtectFromImpersonationTest.php
@@ -37,7 +37,7 @@ class MiddlewareProtectFromImpersonationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_acces_when_no_impersonating()
+    public function it_can_access_when_no_impersonating()
     {
         $this->actingAs($this->user);
         $return = $this->middleware->handle($this->request, function () {
@@ -50,7 +50,7 @@ class MiddlewareProtectFromImpersonationTest extends TestCase
     }
 
     /** @test */
-    public function it_cant_acces_when_impersonating()
+    public function it_cant_access_when_impersonating()
     {
         $this->actingAs($this->admin);
         $this->admin->impersonate($this->user);


### PR DESCRIPTION
- spell "access" correctly
- spell "another" as one word
- use correct tense of "impersonated"
- use singular form of "event"
- use a comma after "by default"
- use "a" instead of "an" if the following word does not start with a vowel sound
- use correct tense of "store"