### PR TITLE
Laravel 11 Support with github tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.gitattributes     export-ignore
+/.github            export-ignore
 /.gitignore         export-ignore
 /tests              export-ignore
 /phpunit.xml        export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,59 @@
+name: "Tests"
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.3, 8.2, 8.1]
+        laravel: ["^11.0", "^10.0", "^9.0", "^8.12"]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: "^11.0"
+            testbench: 9.*
+          - laravel: "^10.0"
+            testbench: 8.*
+          - laravel: "^9.0"
+            testbench: 7.*
+          - laravel: "^8.12"
+            testbench: "^6.23"
+          - laravel: "^7.0"
+            testbench: 5.*
+            php: "8.0"
+            dependency-version: prefer-stable
+          - laravel: "^6.0"
+            testbench: 4.*
+            php: "8.0"
+            dependency-version: prefer-stable
+        exclude:
+            - laravel: "^11.0"
+              php: 8.1
+            - laravel: "^10.0"
+              php: "8.0"
+            - laravel: "^8.12"
+              php: 8.3
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,12 @@
   ],
   "require": {
     "php": "^7.2 | ^8.0",
-    "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0"
+    "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5 | ^8.0 | ^9.0 | ^10.0",
     "mockery/mockery": "^1.3.3",
-    "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
-    "orchestra/database": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0"
+    "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0 | ^9.0"
   },
   "license": "MIT",
   "authors": [

--- a/readme.md
+++ b/readme.md
@@ -21,14 +21,14 @@
 
 ## Requirements
 
-- Laravel 6.x to 9.x
+- Laravel 6.x to 11.x
 - PHP >= 7.2 or >= 8.0
 
 ### Laravel support
 
 | Version       | Release       |
 |:-------------:|:-------------:|
-| 6.x to 10.x   | 1.7           |
+| 6.x to 11.x   | 1.7           |
 | 6.x, 7.x      | 1.6           |
 | 5.8           | 1.5           |
 | 5.7, 5.6      | 1.2           |

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,7 +67,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app)
     {
         return [
-            ConsoleServiceProvider::class,
             ImpersonateServiceProvider::class,
         ];
     }


### PR DESCRIPTION
**Working Demo:** [laravel-impersonate/actions/runs/tests](https://github.com/erikn69/laravel-impersonate/actions/runs/8101804260/job/22142855816)

```batch
PHPUnit 10.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.3
Configuration: /home/runner/work/laravel-impersonate/laravel-impersonate/phpunit.xml

..............................                                    30 / 30 (100%)

Time: 00:10.669, Memory: 34.00 MB

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. 
   Migrate your XML configuration using "--migrate-configuration"!

OK, but there were issues!
Tests: 30, Assertions: 85, Deprecations: 1.
```