### PR TITLE
Respect the hashing.rehash_on_login setting introduced in laravel 11

### DIFF
--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -131,7 +131,12 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
         $auth->extend('session', function (Application $app, $name, array $config) use ($auth) {
             $provider = $auth->createUserProvider($config['provider']);
 
-            $guard = new SessionGuard($name, $provider, $app['session.store']);
+            $guard = new SessionGuard(
+                $name,
+                $provider,
+                $app['session.store'],
+                rehashOnLogin: config('hashing.rehash_on_login', true)
+            );
 
             if (method_exists($guard, 'setCookieJar')) {
                 $guard->setCookieJar($app['cookie']);
@@ -144,6 +149,8 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
             if (method_exists($guard, 'setRequest')) {
                 $guard->setRequest($app->refresh('request', $guard, 'setRequest'));
             }
+
+
 
             return $guard;
         });

--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -131,11 +131,11 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
         $auth->extend('session', function (Application $app, $name, array $config) use ($auth) {
             $provider = $auth->createUserProvider($config['provider']);
 
-            $guard = new SessionGuard(
-                $name,
-                $provider,
+            $guard = new SessionGuard($name, $provider,
                 $app['session.store'],
-                rehashOnLogin: config('hashing.rehash_on_login', true)
+                null,
+                null,
+                config('hashing.rehash_on_login', true)
             );
 
             if (method_exists($guard, 'setCookieJar')) {


### PR DESCRIPTION
Laravel 11 introduced new functionality where it will rehash a user's password on each login unless the config hashing.rehash_on_login is set to false.

We don't use passwords as we only do single sign on.

This passes the setting to the guard created in ImpersonateServiceProvider.