### PR TITLE
Improve function signatures and return type annotations

### DIFF
--- a/src/Controllers/ImpersonateController.php
+++ b/src/Controllers/ImpersonateController.php
@@ -29,7 +29,7 @@ class ImpersonateController extends Controller
      * @return  RedirectResponse
      * @throws  \Exception
      */
-    public function take(Request $request, $id, $guardName = null)
+    public function take(Request $request, int $id, ?string $guardName = null): RedirectResponse
     {
         $guardName = $guardName ?? $this->manager->getDefaultSessionGuard();
 
@@ -64,7 +64,7 @@ class ImpersonateController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function leave()
+    public function leave(): RedirectResponse
     {
         if (!$this->manager->isImpersonating()) {
             abort(403);

--- a/src/Exceptions/InvalidUserProvider.php
+++ b/src/Exceptions/InvalidUserProvider.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class InvalidUserProvider extends \Exception
 {
-    public function __construct(string $guard, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $guard, $message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(sprintf('Invalid user provider for guard %s', $guard), $code, $previous);
     }

--- a/src/Guard/SessionGuard.php
+++ b/src/Guard/SessionGuard.php
@@ -13,7 +13,7 @@ class SessionGuard extends BaseSessionGuard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function quietLogin(Authenticatable $user)
+    public function quietLogin(Authenticatable $user): void
     {
         $this->updateSession($user->getAuthIdentifier());
 
@@ -27,7 +27,7 @@ class SessionGuard extends BaseSessionGuard
      * @param   void
      * @return  void
      */
-    public function quietLogout()
+    public function quietLogout(): void
     {
         $this->clearUserDataFromStorage();
 

--- a/src/Impersonate.php
+++ b/src/Impersonate.php
@@ -12,7 +12,7 @@ class Impersonate extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return ImpersonateManager::class;
     }

--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -27,7 +27,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfig();
 
@@ -50,7 +50,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishConfig();
 
@@ -69,7 +69,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    protected function registerBladeDirectives()
+    protected function registerBladeDirectives(): void
     {
         $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
             $bladeCompiler->directive('impersonating', function ($guard = null) {
@@ -107,7 +107,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    protected function registerRoutesMacro()
+    protected function registerRoutesMacro(): void
     {
         $router = $this->app['router'];
 
@@ -123,7 +123,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    protected function registerAuthDriver()
+    protected function registerAuthDriver(): void
     {
         /** @var AuthManager $auth */
         $auth = $this->app['auth'];
@@ -155,7 +155,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    public function registerMiddleware()
+    public function registerMiddleware(): void
     {
         $this->app['router']->aliasMiddleware('impersonate.protect', ProtectFromImpersonation::class);
     }
@@ -166,7 +166,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    protected function mergeConfig()
+    protected function mergeConfig(): void
     {
         $configPath = __DIR__ . '/../config/' . $this->configName . '.php';
 
@@ -179,7 +179,7 @@ class ImpersonateServiceProvider extends \Illuminate\Support\ServiceProvider
      * @param void
      * @return  void
      */
-    protected function publishConfig()
+    protected function publishConfig(): void
     {
         $configPath = __DIR__ . '/../config/' . $this->configName . '.php';
 

--- a/src/Middleware/ProtectFromImpersonation.php
+++ b/src/Middleware/ProtectFromImpersonation.php
@@ -3,6 +3,7 @@
 namespace Lab404\Impersonate\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Lab404\Impersonate\Services\ImpersonateManager;
 
@@ -15,7 +16,7 @@ class ProtectFromImpersonation
      * @param   \Closure  $next
      * @return  mixed
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
         $impersonate_manager = app()->make(ImpersonateManager::class);
 

--- a/src/Models/Impersonate.php
+++ b/src/Models/Impersonate.php
@@ -13,7 +13,7 @@ trait Impersonate
      * @param void
      * @return  bool
      */
-    public function canImpersonate()
+    public function canImpersonate(): bool
     {
         return true;
     }
@@ -24,7 +24,7 @@ trait Impersonate
      * @param void
      * @return  bool
      */
-    public function canBeImpersonated()
+    public function canBeImpersonated(): bool
     {
         return true;
     }
@@ -36,7 +36,7 @@ trait Impersonate
      * @param string|null $guardName
      * @return  bool
      */
-    public function impersonate(Model $user, $guardName = null)
+    public function impersonate(Model $user, ?string $guardName = null): bool
     {
         return app(ImpersonateManager::class)->take($this, $user, $guardName);
     }
@@ -47,7 +47,7 @@ trait Impersonate
      * @param void
      * @return  bool
      */
-    public function isImpersonated()
+    public function isImpersonated(): bool
     {
         return app(ImpersonateManager::class)->isImpersonating();
     }
@@ -58,7 +58,7 @@ trait Impersonate
      * @param void
      * @return  bool
      */
-    public function leaveImpersonation()
+    public function leaveImpersonation(): bool
     {
         if ($this->isImpersonated()) {
             return app(ImpersonateManager::class)->leave();

--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -3,10 +3,12 @@
 namespace Lab404\Impersonate\Services;
 
 use Exception;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Collection;
 use Lab404\Impersonate\Events\LeaveImpersonation;
 use Lab404\Impersonate\Events\TakeImpersonation;
 use Lab404\Impersonate\Exceptions\InvalidUserProvider;
@@ -31,7 +33,7 @@ class ImpersonateManager
      * @throws InvalidUserProvider
      * @throws ModelNotFoundException
      */
-    public function findUserById($id, $guardName = null)
+    public function findUserById(int $id, ?string $guardName = null): Authenticatable
     {
         if (empty($guardName)) {
             $guardName = $this->app['config']->get('auth.default.guard', 'web');
@@ -70,7 +72,7 @@ class ImpersonateManager
     /**
      * @return  int|null
      */
-    public function getImpersonatorId()
+    public function getImpersonatorId(): ?int
     {
         return session($this->getSessionKey(), null);
     }
@@ -78,7 +80,7 @@ class ImpersonateManager
     /**
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
-    public function getImpersonator()
+    public function getImpersonator(): Authenticatable
     {
         $id = session($this->getSessionKey(), null);
 
@@ -88,7 +90,7 @@ class ImpersonateManager
     /**
      * @return string|null
      */
-    public function getImpersonatorGuardName()
+    public function getImpersonatorGuardName(): ?string
     {
         return session($this->getSessionGuard(), null);
     }
@@ -96,7 +98,7 @@ class ImpersonateManager
     /**
      * @return string|null
      */
-    public function getImpersonatorGuardUsingName()
+    public function getImpersonatorGuardUsingName(): ?string
     {
         return session($this->getSessionGuardUsing(), null);
     }
@@ -107,7 +109,7 @@ class ImpersonateManager
      * @param string|null                         $guardName
      * @return bool
      */
-    public function take($from, $to, $guardName = null)
+    public function take(Authenticatable $from, Authenticatable $to, ?string $guardName = null): bool
     {
         $this->saveAuthCookieInSession();
 
@@ -153,7 +155,7 @@ class ImpersonateManager
         return true;
     }
 
-    public function clear()
+    public function clear(): void
     {
         session()->forget($this->getSessionKey());
         session()->forget($this->getSessionGuard());
@@ -205,7 +207,7 @@ class ImpersonateManager
     /**
      * @return array|null
      */
-    public function getCurrentAuthGuardName()
+    public function getCurrentAuthGuardName(): ?array
     {
         $guards = array_keys(config('auth.guards'));
 
@@ -249,7 +251,7 @@ class ImpersonateManager
      * @param string $search
      * @return \Illuminate\Support\Collection
      */
-    protected function findByKeyInArray(array $values, string $search)
+    protected function findByKeyInArray(array $values, string $search): Collection
     {
         return collect($values ?? session()->all())
             ->filter(function ($val, $key) use ($search) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,7 +10,7 @@ if (! function_exists('can_impersonate')) {
 	 * @param  null  $guard
 	 * @return bool
 	 */
-	function can_impersonate(string $guard = null): bool
+	function can_impersonate(?string $guard = null): bool
 	{
 		$guard = $guard ?? app('impersonate')->getCurrentAuthGuardName();
 
@@ -28,7 +28,7 @@ if (! function_exists('can_be_impersonated')) {
 	 * @param  string|null      $guard
 	 * @return bool
 	 */
-		function can_be_impersonated(Authenticatable $user, string $guard = null): bool
+		function can_be_impersonated(Authenticatable $user, ?string $guard = null): bool
 	{
 		$guard = $guard ?? app('impersonate')->getCurrentAuthGuardName();
 		return app('auth')->guard($guard)->check()
@@ -45,7 +45,7 @@ if (! function_exists('is_impersonating')) {
 	 * @param  string|null  $guard
 	 * @return bool
 	 */
-	function is_impersonating(string $guard = null): bool
+	function is_impersonating(?string $guard = null): bool
 	{
 		$guard = $guard ?? app('impersonate')->getCurrentAuthGuardName();
 


### PR DESCRIPTION
PHP 8.4 introduces the deprecation of implicitly nullable parameters (https://github.com/php/php-src/blob/php-8.4.0RC1/UPGRADING#L497). This PR updates the codebase to be compatible with PHP 8.4, and also improves the function signatures and return type annotations.