### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/Exceptions/InvalidUserProvider.php
+++ b/src/Exceptions/InvalidUserProvider.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class InvalidUserProvider extends \Exception
 {
-    public function __construct(string $guard, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $guard, $message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(sprintf('Invalid user provider for guard %s', $guard), $code, $previous);
     }

--- a/src/Exceptions/MissingUserProvider.php
+++ b/src/Exceptions/MissingUserProvider.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class MissingUserProvider extends \Exception
 {
-    public function __construct(string $guard, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $guard, $message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(sprintf('Missing user provider for guard %s', $guard), $code, $previous);
     }


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Lab404\Impersonate\Exceptions\MissingUserProvider::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in ./src/Exceptions/MissingUserProvider.php on line 9

PHP Deprecated:  Lab404\Impersonate\Exceptions\InvalidUserProvider::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in ./src/Exceptions/InvalidUserProvider.php on line 9
```